### PR TITLE
installing sratoolkit via script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,9 @@ RUN bash install/install-srst2.sh
 COPY ./install-nextflow.sh ./install/install-nextflow.sh
 RUN bash install/install-nextflow.sh
 
+COPY ./install-sra-toolkit.sh ./install/install-sra-toolkit.sh
+RUN bash install/install-sra-toolkit.sh
+
 COPY ./setup-environment.sh ./install/setup-environment.sh
 RUN bash install/setup-environment.sh
 

--- a/install-sra-toolkit.sh
+++ b/install-sra-toolkit.sh
@@ -1,0 +1,15 @@
+# Install sra-toolkit.
+# This was really annoying to install. The only way to get fasterq-dump to work was by running vdb-config --i at least once
+# vdb-config --i causes weird terminal issues. Workaround is to pipe it to null and ignore the exit code =p
+set -e
+
+wget https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/2.10.8/sratoolkit.2.10.8-ubuntu64.tar.gz
+tar -vxzf sratoolkit.2.10.8-ubuntu64.tar.gz
+rm sratoolkit.2.10.8-ubuntu64.tar.gz
+
+set +e
+echo "q" | ./sratoolkit.2.10.8-ubuntu64/bin/vdb-config -i > /dev/null 2>&1
+set -e
+
+ln -s $PWD/sratoolkit.2.10.8-ubuntu64/bin/fasterq-dump /usr/local/bin/fasterq-dump
+ln -s $PWD/sratoolkit.2.10.8-ubuntu64/bin/prefetch /usr/local/bin/prefetch

--- a/test_isolates/jobs/inclusivity.bash
+++ b/test_isolates/jobs/inclusivity.bash
@@ -19,8 +19,11 @@ serovar=$(print_csv_value './test_isolates/data/inclusivity_cases.csv' $TESTCASE
 accession=$(print_csv_value './test_isolates/data/inclusivity_cases.csv' $TESTCASE accession)
 
 # Fetch SRA Data
-prefetch $accession -O ./
-fasterq-dump ./$accession
+# TODO: call prefetch from $PATH rather than /usr/local/bin/
+#       it is being explicitly caleed in this way to disambiguate from the conda install
+#       which is prioritised in the path.
+/usr/local/bin/prefetch $accession -O ./
+/usr/local/bin/fasterq-dump ./$accession
 rm ./$accession/*.sra
 rm -r ./$accession
 


### PR DESCRIPTION
This PR solves the issues downloading ENA data on CircleCI. Turns out when Josh and Aaron neatened the dockerfile, conda downgraded the version of sra-toolkit to 2.9.6, which uses a different file naming convention than the newer version (such as what the TB uses). 

To circumvent this issue in the simplest possible way for now, we are manually installing sra-toolkit from a script, and calling that executable directly from the inclusivity test.

