### PR TITLE
Conditional run or skip sample

### DIFF
--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -317,7 +317,11 @@ process most {
     mv serovar2.txt  ${sample_id}_serovar.tsv 
     fi
     > ${sample_id}_7.txt
-    rm -r $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.pileup
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.fa
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.fa.fai
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.bam
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.bam.bai
     """
 }
 

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -245,7 +245,7 @@ process seqsero2 {
     script:
     """     
    #/opt/conda/bin/conda init bash
-   /opt/conda/bin/SeqSero2_package.py -m a -b mem -t 2 -i \$PWD/${sample_id}_{R1,R2}.fastq.gz -d $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2 > ${sample_id}_5.txt
+   /opt/conda/bin/SeqSero2_package.py -m a -b mem -t 2 -d $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2 -i ${reads_file[0]} ${reads_file[1]} > ${sample_id}_5.txt
     
     """
 }

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -14,7 +14,6 @@ publishDirectory = "$HOME/WGS_Results/${params.runID}/"
 
 println readPath
 
-/*
 Initial pre-processing run at the start of the nextflow run
 process pre_process {
     """
@@ -23,7 +22,7 @@ process pre_process {
     git rev-parse HEAD > $publishDirectory/sha
     """
 }
-*/ 
+
 
 /*
  * PRE-STEP i - count reads
@@ -111,20 +110,14 @@ process subsampling {
     if [ $READCOUNT -gt 4500000 ]
     then
         echo "Greater than 4.5M reads, subsampling to 4M" >> !{sample_id}_subsampling.log
-        # echo $READFILE1 >> !{sample_id}_subsampling.log
-        # echo $OUTNAME1 >> !{sample_id}_subsampling.log
         /opt/conda/bin/seqtk sample -s100 $READFILE1 4000000 > $OUTNAME1
         gzip --fast $OUTNAME1
-        # echo $READFILE2 >> !{sample_id}_subsampling.log
-        # echo $OUTNAME2 >> !{sample_id}_subsampling.log
         /opt/conda/bin/seqtk sample -s100 $READFILE2 4000000 > $OUTNAME2
         gzip --fast $OUTNAME2
-        # echo "Done." >> !{sample_id}_subsampling.log
     else
         echo "Fewer than 4.5M reads, skipping" >> !{sample_id}_subsampling.log
         mv $READFILE1 .
         mv $READFILE2 .
-        # echo "Done." >> !{sample_id}_subsampling.log
     fi
     '''
 }

--- a/plate/process_plate.py
+++ b/plate/process_plate.py
@@ -6,6 +6,7 @@ import argparse
 # TODO: Rename directories to BGE defaults
 DEFAULT_READS_DIRECTORY = os.path.expanduser('~/wgs-reads/')
 DEFAULT_RESULTS_DIRECTORY = os.path.expanduser('~/wgs-results/')
+DEFAULT_IMAGE = "jguzinski/salmonella-seq:prod"
 
 def run(cmd):
     """ Run a command and assert that the process exits with a non-zero exit code.
@@ -22,7 +23,7 @@ def run(cmd):
             cmd failed with exit code %i
         *****""" % (cmd, returncode))
 
-def run_pipeline(reads, results, plate_name, image="jguzinski/salmonella-seq:prod"):
+def run_pipeline(reads, results, plate_name, image=DEFAULT_IMAGE):
     """ Run the Salmonella pipeline using docker """
     run([
         "sudo", "docker", "run", "-it", 
@@ -103,7 +104,7 @@ def run_plate(s3_uri, reads_dir, results_dir):
         rename_fastq_file(filepath)
 
     # Process
-    run_pipeline(plate_reads_dir, plate_results_dir, plate_name)
+    run_pipeline(plate_reads_dir, plate_results_dir, plate_name, image=args.image)
 
     # TODO: Backup in fsx
 
@@ -113,6 +114,7 @@ if __name__ == '__main__':
     parser.add_argument("s3_uri", help="s3 uri that corresponds to the fastq plate to run")
     parser.add_argument("--reads-dir", default=DEFAULT_READS_DIRECTORY,  help="base directory that s3 objects are stored to")
     parser.add_argument("--results-dir", default=DEFAULT_RESULTS_DIRECTORY,  help="base directory where pipeline results are stored")
+    parser.add_argument("--image", default=DEFAULT_IMAGE, help="docker image to use")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Got a little bit sidetracked and started working on the Nextflow code which prevents any samples below a desired minimum readcount (i.e. insufficient data) from actually running through the pipeline. The default value of this params.minReads is currently set to 500,000 in line with the proposed LIMS rule.

For now, the new process and channel operations filter reads into a 'run' channel (sufficient data) and a 'skip' channel (insufficient data). The run channel proceeds to trimming, subsampling and the rest of the pipeline. The skip channel goes nowhere.

Also added a line to remove the large 'tmp' directory produced by MOST.