### PR TITLE
Download files from most phe public repo

### DIFF
--- a/install/install-most.sh
+++ b/install/install-most.sh
@@ -9,7 +9,7 @@ pip install lxml==4.5.2
 pip install biopython==1.73
 
 # TODO: download directly from authour
-wget --no-check-certificate --content-disposition https://raw.githubusercontent.com/APHA-BAC/NextflowSerotypingPipeline/master/pipeline_component_software/most/most.zip
+wget --no-check-certificate --content-disposition https://raw.githubusercontent.com/APHA-BAC/MOST-PHE/tree/main/pipeline_component_software/most/most.zip
 unzip most.zip
 sudo cp -r most /opt
 sudo chmod +x /opt/most/MOST-master/MOST.py

--- a/install/install-most.sh
+++ b/install/install-most.sh
@@ -9,7 +9,7 @@ pip install lxml==4.5.2
 pip install biopython==1.73
 
 # TODO: download directly from authour
-wget --no-check-certificate --content-disposition https://raw.githubusercontent.com/APHA-BAC/MOST-PHE/tree/main/pipeline_component_software/most/most.zip
+wget --no-check-certificate --content-disposition https://raw.githubusercontent.com/APHA-BAC/MOST-PHE/main/pipeline_component_software/most/most.zip
 unzip most.zip
 sudo cp -r most /opt
 sudo chmod +x /opt/most/MOST-master/MOST.py


### PR DESCRIPTION
Thanks Aaron! Didn't notice that GitHub was trying to merge into JaromirGuzinski/NextflowSerotypingPipeline/master rather than APHA-BAC/NextflowSerotypingPipeline/master. Actually I've been caught out a few times by working on the JaromirGuzinski repo thinking I was in the APHA-BAC repo. Maybe I can just get rid of this entire thing? https://github.com/JaromirGuzinski/NextflowSerotypingPipeline

But if this is looking good for MOST, I will do something similar for the other software in the pipeline_component_software/ dir. May get onto that this week and/or next week.