### PR TITLE
Instantiate summary table

### DIFF
--- a/summaryTable_reworked.py
+++ b/summaryTable_reworked.py
@@ -16,21 +16,50 @@ import numpy
 import fnmatch
 import glob
 import zipfile
+import argparse
+import pandas as pd
 
 ####################################################################################################
 
-tableHeader = ["StrainID", "Consensus", "#ReadsR1", "GC%R1", "R1Kmerid", "ContaminationFlag", 
-"MOST", "Most_light", "st", "MLST", "MLST mean cov", 
-"SeqSero", "SS comment", "N50", "serogroup", "serovar", "serovar_antigen", "serovar_cgmlst", 
-"vaccine", "mono", "sseJ", 
-"ReadLenRange", "#Contigs", "#Contigs>25Kbp", "#Contigs>50Kbp", "AssemblySize", "AssemblyGC", "L50"]
+tableHeader = [
+"Consensus", 
+"#Reads_raw", 
+"#Reads_filtered", 
+"GC%", 
+"KmerID", 
+"Contam_Flag", 
+"MOST", 
+"MOST_Light", 
+"MOST_ST", 
+"MLST", 
+"MLST_meanCov", 
+"SeqSero", 
+"SeqSero_comment",
+"N50",
+"sistr_Serogroup",
+"sistr_Serovar",
+"serovar_antigen", 
+"serovar_cgmlst", 
+"vaccine", 
+"mono", 
+"sseJ", 
+"ReadLenRange", 
+"#Contigs", 
+"#Contigs>25Kbp", 
+"#Contigs>50Kbp", 
+"AssemblySize", 
+"AssemblyGC", 
+"L50"
+]
+
+# tableHeader = ["StrainID", "Consensus", "#ReadsR1", "GC%R1", "R1Kmerid", "ContaminationFlag", "MOST", "Most_light", "st", "MLST", "MLST mean cov", "SeqSero", "SS comment", "N50", "serogroup", "serovar", "serovar_antigen", "serovar_cgmlst", "vaccine", "mono", "sseJ", "ReadLenRange", "#Contigs", "#Contigs>25Kbp", "#Contigs>50Kbp", "AssemblySize", "AssemblyGC", "L50"]
 
 ####################################################################################################
 
-def writeCSV(fname, matrix):
-    with open(fname, "w") as fileOut:
-        writer = csv.writer(fileOut)
-        writer.writerows(matrix)
+# def writeCSV(fname, matrix):
+#     with open(fname, "w") as fileOut:
+#         writer = csv.writer(fileOut)
+#         writer.writerows(matrix)
 
 def readTable(fname):
     infile = open(fname, "r")
@@ -51,17 +80,29 @@ def get_subdirs(direc):
 
 
 ####################################################################################################
+# Get original readcount
+def raw_count(sampleDir, sampleID):
+    readcountDir = os.path.join(sampleDir, "readcount")
+    readcountFile = os.path.join(readcountDir, "{}_readcount.txt".format(sampleID))
+    if not os.path.exists(readcountFile) or os.path.getsize(readcountFile) == 0:
+        return None
+    with open(readcountFile) as inFile:
+        rawCount = int(inFile.readline().strip())
+    return rawCount
+
+
+####################################################################################################
 # Get QC metrics from FastQC
 
-def fastqc_summary(sampleDir):
+def fastqc_summary(sampleDir, sampleID):
     fastqcDir = os.path.join(sampleDir, "FASTQC_Reports")
     fastqcZip = [x for x in glob.glob(os.path.join(fastqcDir, "{}*_R1_fastqc.zip".format(sampleID)))]
     if len(fastqcZip) == 0 or os.path.getsize(fastqcZip[0]) == 0:
-        return "NoResults", "NoResults", "NoResults", "NoResults"
+        return None, None, None, None
     with zipfile.ZipFile(fastqcZip[0], 'r') as archive:
         fastqcOutFile = [x for x in archive.namelist() if 'fastqc_data.txt' in x]
         if len(fastqcOutFile) == 0:
-            return "NoResults", "NoResults", "NoResults", "NoResults"
+            return None, None, None, None
         with archive.open(fastqcOutFile[0]) as fastqcOut:
             for line in fastqcOut:
                 line = line.decode('utf-8').strip()
@@ -79,11 +120,11 @@ def fastqc_summary(sampleDir):
 ####################################################################################################
 # kmerid analysis - can now account for variable tsv file names from kmerid
 
-def kmerid_summary(sampleDir):
+def kmerid_summary(sampleDir, sampleID):
     kmeridDir = os.path.join(sampleDir, "Kmerid")
     kmeridOut = [x for x in glob.glob(os.path.join(kmeridDir, "{}*_R1.tsv".format(sampleID)))]
     if len(kmeridOut) == 0 or os.path.getsize(kmeridOut[0]) == 0:
-        return "NoResults", "NoResults"
+        return None, None
     kmeridOut = kmeridOut[0]
     kmeridResults = readTable(kmeridOut)
     kmeridResults = kmeridResults[2:]
@@ -117,7 +158,7 @@ def most_summary(sampleDir):
     mostFile = [x for x in glob.glob(os.path.join(mostDir, "*MLST_result.csv"))]
     lightFile = [x for x in glob.glob(os.path.join(mostDir, "*.results.xml"))]
     if len(lightFile) == 0 or os.path.getsize(lightFile[0]) == 0:
-        light = "NoResults"
+        light = None
     else:
         lightF = open(lightFile[0], "r")
         lightText = lightF.readlines()
@@ -129,10 +170,10 @@ def most_summary(sampleDir):
         if any("RED" in x for x in lightText):
             light = "RED"
     if len(mostFile) == 0 or os.path.getsize(mostFile[0]) == 0:
-        mostType = "NoResults"
-        st = "NoResults"
-        meanMLSTCov = "NoResults"
-        mlst = "NoResults"
+        mostType = None
+        st = None
+        meanMLSTCov = None
+        mlst = None
     else:
         mostFileName = mostFile[0]
         mostResults = readTable(mostFileName)
@@ -170,8 +211,8 @@ def seqsero_summary(sampleDir):
     seqseroDir = os.path.join(sampleDir, "SeqSero2")
     seqseroFile = [x for x in glob.glob(os.path.join(seqseroDir, "SeqSero_result.txt"))]
     if len(seqseroFile) == 0 or os.path.getsize(seqseroFile[0]) == 0:
-        seqseroType = "NoResults"
-        seqseroComment = "NoResults"
+        seqseroType = None
+        seqseroComment = None
     else:
         seqseroFileName = seqseroFile[0]
         seqseroFile = open(seqseroFileName, "r")
@@ -192,7 +233,7 @@ def quast_summary(sampleDir):
     quastDir = os.path.join(sampleDir, "quast")
     quastFile = [x for x in glob.glob(os.path.join(quastDir, "transposed_report.tsv"))]
     if len(quastFile) == 0 or os.path.getsize(quastFile[0]) == 0:
-        contigs25k = contigs50k = contigs = assemLen = assemGC = N50 = L50 = "NoQuast"
+        contigs25k = contigs50k = contigs = assemLen = assemGC = N50 = L50 = None
     else:
         quastOut = readTable(quastFile[0])
         if len(quastOut) > 1:
@@ -214,10 +255,10 @@ def sistr_summary(sampleDir):
     sistrDir = os.path.join(sampleDir, "sistr")
     sistrFile = [x for x in glob.glob(os.path.join(sistrDir, "sistr_prediction.csv"))]
     if len(sistrFile) == 0 or os.path.getsize(sistrFile[0]) == 0:
-        serogroup = "NoResults"
-        serovar = "NoResults"
-        serovar_antigen = "NoResults"
-        serovar_cgmlst = "NoResults"
+        serogroup = None
+        serovar = None
+        serovar_antigen = None
+        serovar_cgmlst = None
     else:
         tab = readTable(sistrFile[0])
         serogroupind = tab[0].index("serogroup")
@@ -406,42 +447,152 @@ def paratyphiB_java_diff(sampleDir, mostType):
 ####################################################################################################
 ####################################################################################################
 
-del sys.argv[0]
 
-if not len(sys.argv) == 1:
-    sys.exit("Error, no run name specified")
+def instantiate_summary(resultsDir, runID):
+    sampleDirs = get_subdirs(resultsDir)
+    sampleNames = [os.path.basename(x) for x in sampleDirs]
+    df = pd.DataFrame(columns = tableHeader, index = sampleNames)
+    df.index.rename('Isolate_ID', inplace=True)
+    df = df.fillna('no_result')
+    for sampleDir in sampleDirs:
+        sampleID = os.path.basename(sampleDir)
+        rawCount = raw_count(sampleDir, sampleID)
+        if rawCount:
+            df.loc[sampleID, "#Reads_raw"] = rawCount
+    summaryFileName = os.path.join(resultsDir, runID + "_SummaryTable.csv")
+    print(df)
+    df.to_csv(summaryFileName)
 
-runID = sys.argv[0]
-print(runID)
-resultsDir = os.path.join(os.path.expanduser("~/WGS_Results"), runID)
-print(resultsDir)
-outTable = [tableHeader]
-sampleDirs = get_subdirs(resultsDir)
+def fill_summary(resultsDir, runID):
+    summaryFileName = os.path.join(resultsDir, runID + "_SummaryTable.csv")
+    df = pd.read_csv(summaryFileName, index_col=0)
+    sampleDirs = get_subdirs(resultsDir)
+    for sampleDir in sampleDirs:
+        sampleID = os.path.basename(sampleDir)
+        readCount, poorReads, readLen, gcR1 = fastqc_summary(sampleDir, sampleID)
+        if readCount:
+            df.loc[sampleID, "#Reads_filtered"] = readCount
+        if readLen:
+            df.loc[sampleID, "ReadLenRange"] = readLen
+        if gcR1:
+            df.loc[sampleID, "GC%"] = gcR1
+        R1Kmerid, kmeridFlag = kmerid_summary(sampleDir, sampleID)
+        if R1Kmerid:
+            df.loc[sampleID, "KmerID"] = R1Kmerid
+        if kmeridFlag:
+            df.loc[sampleID, "Contam_Flag"] = kmeridFlag
+        light, mostType, st, meanMLSTCov, mlst = most_summary(sampleDir)
+        if light:
+            df.loc[sampleID, "MOST_Light"] = light
+        if mostType:
+            df.loc[sampleID, "MOST"] = mostType
+        if st:
+            df.loc[sampleID, "MOST_ST"] = st
+        if meanMLSTCov:
+            df.loc[sampleID, "MLST_meanCov"] = meanMLSTCov
+        if mlst:
+            df.loc[sampleID, "MLST"] = mlst
+        seqseroType, seqseroComment = seqsero_summary(sampleDir)
+        if seqseroType:
+            df.loc[sampleID, "SeqSero"] = seqseroType
+        if seqseroComment:
+            df.loc[sampleID, "SeqSero_comment"] = seqseroComment
+        contigs25k, contigs50k, contigs, assemLen, assemGC, N50, L50 = quast_summary(sampleDir)
+        if contigs25k:
+            df.loc[sampleID, "#Contigs>25Kbp"] = contigs25k
+        if contigs50k:
+            df.loc[sampleID, "#Contigs>50Kbp"] = contigs50k
+        if contigs:
+            df.loc[sampleID, "#Contigs"] = contigs
+        if assemLen:
+            df.loc[sampleID, "AssemblySize"] = assemLen
+        if assemGC:
+            df.loc[sampleID, "AssemblyGC"] = assemGC
+        if N50:
+            df.loc[sampleID, "N50"] = N50
+        if L50:
+            df.loc[sampleID, "L50"] = L50
+        serogroup, serovar, serovar_antigen, serovar_cgmlst = sistr_summary(sampleDir)
+        if serogroup:
+            df.loc[sampleID, "sistr_Serogroup"] = serogroup
+        if serovar:
+            df.loc[sampleID, "sistr_Serovar"] = serovar
+        if serovar_antigen:
+            df.loc[sampleID, "serovar_antigen"] = serovar_antigen
+        if serovar_cgmlst:
+            df.loc[sampleID, "serovar_cgmlst"] = serovar_cgmlst
+        consensus = calc_consensus(seqseroType, mostType, serovar)
+        if consensus:
+            df.loc[sampleID, "Consensus"] = consensus
+        vaccine = vaccine_diff(sampleDir, serovar)
+        if vaccine:
+            df.loc[sampleID, "vaccine"] = vaccine
+        mono = thirteen23i_diff(sampleDir, mostType)
+        if mono:
+            df.loc[sampleID, "mono"] = mono
+        sseJ = paratyphiB_java_diff(sampleDir, mostType)
+        if sseJ:
+            df.loc[sampleID, "sseJ"] = sseJ
+    print(df)
+    df.to_csv(summaryFileName)
 
-for sampleDir in sampleDirs:
-    sampleID = os.path.basename(sampleDir)
-    print(sampleID)
-    readCount, poorReads, readLen, gcR1 = fastqc_summary(sampleDir)
-    R1Kmerid, kmeridFlag = kmerid_summary(sampleDir)
-    light, mostType, st, meanMLSTCov, mlst = most_summary(sampleDir)
-    seqseroType, seqseroComment = seqsero_summary(sampleDir)
-    contigs25k, contigs50k, contigs, assemLen, assemGC, N50, L50 = quast_summary(sampleDir)
-    serogroup, serovar, serovar_antigen, serovar_cgmlst = sistr_summary(sampleDir)
-    consensus = calc_consensus(seqseroType, mostType, serovar)
-    vaccine = vaccine_diff(sampleDir, serovar)
-    mono = thirteen23i_diff(sampleDir, mostType)
-    sseJ = paratyphiB_java_diff(sampleDir, mostType)
-    outTable.append([sampleID, consensus, readCount, gcR1, R1Kmerid, kmeridFlag, mostType, light, st, mlst, meanMLSTCov, 
-        seqseroType, seqseroComment, N50, serogroup, serovar, serovar_antigen, serovar_cgmlst, 
-        vaccine, mono, sseJ, readLen, contigs, contigs25k, contigs50k, assemLen, assemGC, L50])
+# Command line args
+def main():
+    parser = argparse.ArgumentParser(description="Create summary table from Salmonella pipeline run.")
+    parser.add_argument("runID", help="The run ID of the specific pipeline output to be analysed, e.g. 1234 would be the run ID for ~/WGS_Results/1234")
+    parser.add_argument("--instantiate", default=False, action='store_true')
+    args = parser.parse_args()
+    return args
 
-writeCSV(os.path.join(resultsDir, runID+"_SummaryTable.csv"), outTable)
+if __name__ == '__main__':
+    args = main()
+    runID = args.runID
+    print(runID)
+    resultsDir = os.path.join(os.path.expanduser("~/WGS_Results"), runID)
+    print(resultsDir)
+    if args.instantiate:
+        print("Instantiating summary table...")
+        instantiate_summary(resultsDir, runID)
+    else:
+        fill_summary(resultsDir, runID)
 
 quit()
 
 
 
 
+
+# del sys.argv[0]
+
+# if not len(sys.argv) == 1:
+#     sys.exit("Error, no run name specified")
+
+
+# runID = sys.argv[0]
+# print(runID)
+# resultsDir = os.path.join(os.path.expanduser("~/WGS_Results"), runID)
+# print(resultsDir)
+# outTable = [tableHeader]
+# sampleDirs = get_subdirs(resultsDir)
+
+# for sampleDir in sampleDirs:
+#     sampleID = os.path.basename(sampleDir)
+#     print(sampleID)
+#     readCount, poorReads, readLen, gcR1 = fastqc_summary(sampleDir)
+#     R1Kmerid, kmeridFlag = kmerid_summary(sampleDir)
+#     light, mostType, st, meanMLSTCov, mlst = most_summary(sampleDir)
+#     seqseroType, seqseroComment = seqsero_summary(sampleDir)
+#     contigs25k, contigs50k, contigs, assemLen, assemGC, N50, L50 = quast_summary(sampleDir)
+#     serogroup, serovar, serovar_antigen, serovar_cgmlst = sistr_summary(sampleDir)
+#     consensus = calc_consensus(seqseroType, mostType, serovar)
+#     vaccine = vaccine_diff(sampleDir, serovar)
+#     mono = thirteen23i_diff(sampleDir, mostType)
+#     sseJ = paratyphiB_java_diff(sampleDir, mostType)
+#     outTable.append([sampleID, consensus, readCount, gcR1, R1Kmerid, kmeridFlag, mostType, light, st, mlst, meanMLSTCov, 
+#         seqseroType, seqseroComment, N50, serogroup, serovar, serovar_antigen, serovar_cgmlst, 
+#         vaccine, mono, sseJ, readLen, contigs, contigs25k, contigs50k, assemLen, assemGC, L50])
+
+# writeCSV(os.path.join(resultsDir, runID+"_SummaryTable.csv"), outTable)
 
 # def filterDirs(folder):
 #     return [d for d in (os.path.join(folder, d1) for d1 in os.listdir(folder)) if os.path.isdir(d)]


### PR DESCRIPTION
Modified the Summary Table Python script to:
1. Use Pandas rather than lists of lists (still needs a lot of tidying in future!)
2. Use argparse
3. Take a command line option to instantiate an empty summary table at the beginning of a pipeline run, populated with just the raw read count (from the non-subsampled, non-trimmed fastq files) and all other values set to 'no_results'
4. Read the initial empty summary table and overwrite these values at the end of a pipeline run

This gets around the problem of any samples which are below the 'Run Threshold' not being represented in the Summary Table.

Also added a Nextflow process which kicks in after the initial readcount and instantiates the summary table as above