### PR TITLE
Space saving

### DIFF
--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -107,7 +107,7 @@ process fastp_qual_trim {
     tuple sample_id, readCount, readFile1, readFile2 from runCh
 
     output:
-    file("*_fastp.log")
+    file("*_fastp.log") into cleanup_ch1
     tuple sample_id, file("*_{R1,R2}.fastq.gz") into cleanedReads
 
     script:
@@ -128,7 +128,8 @@ process subsampling {
     tuple sample_id, readPair from cleanedReads
     
     output:
-    file("*_subsampling.log")
+    val sample_id into cleanup_ch2
+    file("*_subsampling.log") into cleanup_ch3
     tuple sample_id, file("*_{R1,R2}.fastq.gz") into reads1, reads2, reads3, reads4, reads5, reads6, reads7, reads8, reads9, reads_summ1, reads_summ2
 
     shell:

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -4,7 +4,7 @@
  * PRE-STEP i - define the input path to the sequences that will be analysed
 */ 
 
-params.minReads = 300000
+params.minReads = 500000
 params.subsampThreshold = 3500000
 subsamp = params.subsampThreshold - 500000
 println subsamp

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -168,12 +168,13 @@ process intermediate_reads_cleanup {
     shell:
     '''
     sleep 30
-    DIR=$(dirname !{logfile})
-    ls $DIR/*.fastq.gz > cleanup.log || echo "no files found"
-    rm $DIR/*.fastq.gz || echo "nothing to delete"
-    ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz >> cleanup.log || echo "no files found"
+    CLEANUPDIR=$(dirname !{logfile})
+    echo !{sample_id} > cleanup.txt
+    ls $CLEANUPDIR/*.fastq.gz >> cleanup.txt || echo "no files found"
+    rm $CLEANUPDIR/*.fastq.gz || echo "nothing to delete"
+    ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz >> cleanup.txt || echo "no files found"
     rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz || echo "nothing to delete"
-    ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/subsampling/*.fastq.gz >> cleanup.log || echo "no files found"
+    ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/subsampling/*.fastq.gz >> cleanup.txt || echo "no files found"
     rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/subsampling/*.fastq.gz || echo "nothing to delete"
     '''
 }

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -472,13 +472,13 @@ process remove {
 
     script: 
     """
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/FASTQC_Reports/${sample_id}_1.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/shovill/${sample_id}_2.txt 
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/quast/${sample_id}_3.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/Kmerid/${sample_id}_4.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2/${sample_id}_5.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/sistr/${sample_id}_6.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_7.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/srst2/${sample_id}_8.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/FASTQC_Reports/${sample_id}_1.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/shovill/${sample_id}_2.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/quast/${sample_id}_3.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/Kmerid/${sample_id}_4.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2/${sample_id}_5.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/sistr/${sample_id}_6.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_7.txt || echo "nothing to delete"
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/srst2/${sample_id}_8.txt || echo "nothing to delete"
     """
 }

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -345,7 +345,7 @@ process most {
 
     script:
     """    
-    python /opt/most/MOST-master/MOST.py -1 \$PWD/${sample_id}_R1.fastq.gz  -2 \$PWD/${sample_id}_R2.fastq.gz -st /opt/most/MOST-master/MLST_data/salmonella --output_directory $HOME/WGS_Results/${params.runID}/${sample_id}/MOST -serotype True --bowtie /opt/most/bowtie2-2.1.0/bowtie2 --samtools /opt/most/samtools-0.1.18/samtools
+    python /opt/most/MOST-master/MOST.py -1 ${reads_file[0]} -2 ${reads_file[1]} -st /opt/most/MOST-master/MLST_data/salmonella --output_directory $HOME/WGS_Results/${params.runID}/${sample_id}/MOST -serotype True --bowtie /opt/most/bowtie2-2.1.0/bowtie2 --samtools /opt/most/samtools-0.1.18/samtools
     if grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml
     then
         grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -343,32 +343,32 @@ process most {
     file("${sample_id}_7.txt") into out7_ch_rem   
     set sample_id, file("${sample_id}_serovar.tsv") into most_out_ch
 
-    script:
-    """    
-    python /opt/most/MOST-master/MOST.py -1 ${reads_file[0]} -2 ${reads_file[1]} -st /opt/most/MOST-master/MLST_data/salmonella --output_directory $HOME/WGS_Results/${params.runID}/${sample_id}/MOST -serotype True --bowtie /opt/most/bowtie2-2.1.0/bowtie2 --samtools /opt/most/samtools-0.1.18/samtools
-    if grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml
+    shell:
+    '''  
+    python /opt/most/MOST-master/MOST.py -1 !{reads_file[0]} -2 !{reads_file[1]} -st /opt/most/MOST-master/MLST_data/salmonella --output_directory $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST -serotype True --bowtie /opt/most/bowtie2-2.1.0/bowtie2 --samtools /opt/most/samtools-0.1.18/samtools
+    if grep "predicted_serotype" $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/!{sample_id}_R1.fastq.results.xml
     then
-        grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt
+        grep "predicted_serotype" $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/!{sample_id}_R1.fastq.results.xml >> serovar1.txt
         if grep -q "ST-serotype" serovar1.txt
         then
             awk '{print substr(\$2,1,5); }' serovar1.txt > serovar2.txt
-            mv serovar2.txt  ${sample_id}_serovar.tsv 
+            mv serovar2.txt  !{sample_id}_serovar.tsv 
         else
             awk '{print substr(\$3,10); }' serovar1.txt > serovar2.txt   
-            mv serovar2.txt  ${sample_id}_serovar.tsv 
+            mv serovar2.txt  !{sample_id}_serovar.tsv 
         fi
     else
-        grep "profile" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt
+        grep "profile" $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/!{sample_id}_R1.fastq.results.xml >> serovar1.txt
         awk '{print substr(\$3,1,5); }' serovar1.txt > serovar2.txt
-        mv serovar2.txt  ${sample_id}_serovar.tsv 
+        mv serovar2.txt  !{sample_id}_serovar.tsv 
     fi
-    touch ${sample_id}_7.txt
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.pileup
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.fa
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.fa.fai
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.bam
-    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.bam.bai
-    """
+    touch !{sample_id}_7.txt
+    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/tmp/*.pileup
+    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/tmp/*.fa
+    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/tmp/*.fa.fai
+    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/tmp/*.bam
+    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/MOST/tmp/*.bam.bai
+    '''
 }
 
 

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -196,7 +196,7 @@ process fastqc {
     script:
     """
     fastqc  -f fastq -q ${reads_file}
-   > ${sample_id}_1.txt 
+    touch ${sample_id}_1.txt 
     """
 }
 
@@ -223,8 +223,8 @@ process shovill {
     """    
     /opt/conda/bin/shovill --R1 ${sample_id}_R1.fastq.gz --R2 ${sample_id}_R2.fastq.gz
     mv contigs.fa ${sample_id}_contigs.fa
-   > ${sample_id}_2.txt 
-   """
+    touch ${sample_id}_2.txt
+    """
 }
 
 
@@ -233,8 +233,8 @@ process shovill {
 */ 
 
 quast_ch
-.join(reads3)
-.set { quast_in }
+    .join(reads3)
+    .set { quast_in }
 
 process quast {
     publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/quast",  mode: 'copy'
@@ -250,7 +250,7 @@ process quast {
     script:
     """
     python /usr/local/bin/quast.py -o $HOME/WGS_Results/${params.runID}/${sample_id}/quast "${sample_id}_contigs.fa"
-    > ${sample_id}_3.txt
+    touch ${sample_id}_3.txt
     """
 }
 
@@ -273,7 +273,7 @@ process kmerid {
     script:
     """     
     python /opt/kmerid/kmerid_python3.py -f ${reads_file[0]} -c /opt/kmerid/config/config.cnf -n > ${sample_id}_R1.tsv
-   > ${sample_id}_4.txt 
+    touch ${sample_id}_4.txt 
     """
 }
 
@@ -283,8 +283,7 @@ process kmerid {
 */ 
 
 process seqsero2 {
-   publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2", mode: 'copy'
-
+    publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2", mode: 'copy'
 
     input:
     tuple sample_id, file(reads_file) from reads5
@@ -294,25 +293,24 @@ process seqsero2 {
     file("${sample_id}_5.txt") into out5_ch_rem   
    
     script:
-    """     
-   #/opt/conda/bin/conda init bash
-   /opt/conda/bin/SeqSero2_package.py -m a -b mem -t 2 -d $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2 -i ${reads_file[0]} ${reads_file[1]} > ${sample_id}_5.txt
-    
+    """
+    /opt/conda/bin/SeqSero2_package.py -m a -b mem -t 2 -d $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2 -i ${reads_file[0]} ${reads_file[1]}
+    touch ${sample_id}_5.txt
     """
 }
 
 
 /*
  * STEP 6 - sistr 
-*/ 
+*/
+
 sistr_ch
-.join(reads6)
-.set { sistr_in }
+    .join(reads6)
+    .set { sistr_in }
 
 
 process sistr {
-   publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/sistr", mode: 'move'
-
+    publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/sistr", mode: 'move'
 
     input:
     set sample_id, file("${sample_id}_contigs.fa"), file (reads_file) from sistr_in
@@ -321,12 +319,11 @@ process sistr {
     file 'sistr_prediction.csv' into sistr_out_ch  
     file("${sample_id}_6.txt") into out6_ch   
     file("${sample_id}_6.txt") into out6_ch_rem   
-
-       
+      
     script:
     """     
     /opt/conda/bin/sistr -i "${sample_id}_contigs.fa" ${sample_id} -f csv -o sistr_prediction.csv --qc
-    > ${sample_id}_6.txt
+    touch ${sample_id}_6.txt
     """
 }
 
@@ -336,8 +333,7 @@ process sistr {
 */ 
 
 process most {
-   publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/MOST", mode: 'copy'
-
+    publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/MOST", mode: 'copy'
 
     input:
     tuple sample_id, file(reads_file) from reads7
@@ -347,27 +343,26 @@ process most {
     file("${sample_id}_7.txt") into out7_ch_rem   
     set sample_id, file("${sample_id}_serovar.tsv") into most_out_ch
 
-   
     script:
     """    
     python /opt/most/MOST-master/MOST.py -1 \$PWD/${sample_id}_R1.fastq.gz  -2 \$PWD/${sample_id}_R2.fastq.gz -st /opt/most/MOST-master/MLST_data/salmonella --output_directory $HOME/WGS_Results/${params.runID}/${sample_id}/MOST -serotype True --bowtie /opt/most/bowtie2-2.1.0/bowtie2 --samtools /opt/most/samtools-0.1.18/samtools
     if grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml
     then
-    grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt
-    if grep -q "ST-serotype" serovar1.txt
-    then
-    awk '{print substr(\$2,1,5); }' serovar1.txt > serovar2.txt
-    mv serovar2.txt  ${sample_id}_serovar.tsv 
+        grep "predicted_serotype" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt
+        if grep -q "ST-serotype" serovar1.txt
+        then
+            awk '{print substr(\$2,1,5); }' serovar1.txt > serovar2.txt
+            mv serovar2.txt  ${sample_id}_serovar.tsv 
+        else
+            awk '{print substr(\$3,10); }' serovar1.txt > serovar2.txt   
+            mv serovar2.txt  ${sample_id}_serovar.tsv 
+        fi
     else
-    awk '{print substr(\$3,10); }' serovar1.txt > serovar2.txt   
-    mv serovar2.txt  ${sample_id}_serovar.tsv 
+        grep "profile" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt
+        awk '{print substr(\$3,1,5); }' serovar1.txt > serovar2.txt
+        mv serovar2.txt  ${sample_id}_serovar.tsv 
     fi
-    else
-    grep "profile" $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_R1.fastq.results.xml >> serovar1.txt
-    awk '{print substr(\$3,1,5); }' serovar1.txt > serovar2.txt
-    mv serovar2.txt  ${sample_id}_serovar.tsv 
-    fi
-    > ${sample_id}_7.txt
+    touch ${sample_id}_7.txt
     rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.pileup
     rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.fa
     rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/tmp/*.fa.fai
@@ -382,37 +377,32 @@ process most {
 */ 
 
 most_out_ch
-.join(reads8)
-.set { sero_in }
+    .join(reads8)
+    .set { sero_in }
 
 
 process srst2 {
-   publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/srst2", mode: 'copy'
-
+    publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/srst2", mode: 'copy'
 
     input:
     set sample_id, file("${sample_id}_serovar.tsv"), file (reads_file) from sero_in
-
-
 
     output:
     file("${sample_id}_8.txt") into out8_ch   
     file("${sample_id}_8.txt") into out8_ch_rem   
 
-
-    script:    
-
-          """
+    script:
+    """
     if grep -E "(Typhimurium|Enteritidis|Gallinarum|Pullorum|Idikan|Kedougou|Java|Paratyphi)" ${sample_id}_serovar.tsv 
     then
     export SRST2_BOWTIE2=/opt/srst2/bowtie2-2.2.3/bowtie2
     export SRST2_BOWTIE2_BUILD=/opt/srst2/bowtie2-2.2.3/bowtie2-build
     srst2.py  --input_pe ${sample_id}_R1.fastq.gz ${sample_id}_R2.fastq.gz --forward _R1 --reverse _R2 --output $HOME/WGS_Results/${params.runID}/${sample_id}/srst2/ --log --gene_db /opt/srst2/VaccineDifferentiation/allVacDB9h1_clustered.fasta
-    > ${sample_id}_8.txt    
+    touch ${sample_id}_8.txt    
     else 
-    > ${sample_id}_8.txt
+    touch ${sample_id}_8.txt
     fi
-        """    
+    """    
 }
 
 
@@ -421,43 +411,33 @@ process srst2 {
 */ 
 
 process summary {
+    input:
+    val read from reads_summ1.count()
+        .view()
+    val c1 from out1_ch.count()
+        .view()
+    val c2 from out2_ch.count()
+        .view()
+    val c3 from out3_ch.count()
+        .view()
+    val c4 from out4_ch.count()
+        .view()
+    val c5 from out5_ch.count()
+        .view()
+    val c6 from out6_ch.count()
+        .view()
+    val c7 from out7_ch.count()
+        .view()
+    val c8 from out8_ch.count()
+        .view()
 
-  input:  
-  val read from reads_summ1.count()
-  .view()
+    when:
+    c1 + c2 + c3 + c4+ c5+ c6 + c7 + c8 == read*8
 
-  val c1 from out1_ch.count()
-  .view()
-
-  val c2 from out2_ch.count()
-  .view()
-
-  val c3 from out3_ch.count()
-  .view()
-
-  val c4 from out4_ch.count()
-  .view()
-
-  val c5 from out5_ch.count()
-  .view()
-
-  val c6 from out6_ch.count()
-  .view()
-
-  val c7 from out7_ch.count()
-  .view()
-
- val c8 from out8_ch.count()
-  .view()
-
-
-  when: 
-  c1 + c2 + c3 + c4+ c5+ c6 + c7 + c8 == read*8
-   
-  script: 
-  """ 
-  python $HOME/summary/summaryTable_reworked.py ${params.runID}
-  """
+    script:
+    """
+    python $HOME/summary/summaryTable_reworked.py ${params.runID}
+    """
 }
 
 
@@ -466,50 +446,39 @@ process summary {
 */
 
 process remove {
+    input:
+    tuple sample_id, file(reads_file) from reads9
+    val read_rem from reads_summ2.count()
+        .view()
+    val c1_rem from out1_ch_rem.count()
+        .view()
+    val c2_rem from out2_ch_rem.count()
+        .view()
+    val c3_rem from out3_ch_rem.count()
+        .view()
+    val c4_rem from out4_ch_rem.count()
+        .view()
+    val c5_rem from out5_ch_rem.count()
+        .view()
+    val c6_rem from out6_ch_rem.count()
+        .view()
+    val c7_rem from out7_ch_rem.count()
+        .view()
+    val c8_rem from out8_ch_rem.count()
+        .view()
 
-  input:  
-  tuple sample_id, file(reads_file) from reads9   
+    when:
+    c1_rem + c2_rem + c3_rem + c4_rem + c5_rem+ c6_rem + c7_rem + c8_rem == read_rem*8
 
-  input:  
-  val read_rem from reads_summ2.count()
-  .view()
-
-  val c1_rem from out1_ch_rem.count()
-  .view()
-
-  val c2_rem from out2_ch_rem.count()
-  .view()
-
-  val c3_rem from out3_ch_rem.count()
-  .view()
-
-  val c4_rem from out4_ch_rem.count()
-  .view()
-
-  val c5_rem from out5_ch_rem.count()
-  .view()
-
-  val c6_rem from out6_ch_rem.count()
-  .view()
-
-  val c7_rem from out7_ch_rem.count()
-  .view()
-
-  val c8_rem from out8_ch_rem.count()
-  .view()
-
-  when: 
-  c1_rem + c2_rem + c3_rem + c4_rem + c5_rem+ c6_rem + c7_rem + c8_rem == read_rem*8
-   
-  script: 
-  """ 
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/FASTQC_Reports/${sample_id}_1.txt
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/shovill/${sample_id}_2.txt 
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/quast/${sample_id}_3.txt
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/Kmerid/${sample_id}_4.txt
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2/${sample_id}_5.txt
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/sistr/${sample_id}_6.txt
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_7.txt
-  rm $HOME/WGS_Results/${params.runID}/${sample_id}/srst2/${sample_id}_8.txt
-  """
+    script: 
+    """
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/FASTQC_Reports/${sample_id}_1.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/shovill/${sample_id}_2.txt 
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/quast/${sample_id}_3.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/Kmerid/${sample_id}_4.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/SeqSero2/${sample_id}_5.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/sistr/${sample_id}_6.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/MOST/${sample_id}_7.txt
+    rm $HOME/WGS_Results/${params.runID}/${sample_id}/srst2/${sample_id}_8.txt
+    """
 }


### PR DESCRIPTION
Added a new Nextflow process to delete the following sets of intermediate readfiles after the Subsampling process has finished:
1. fastp-trimmed reads in Nextflow $WORK
2. copy of fastp-trimmed reads in $HOME
3. copy of subsampled reads in $HOME

These 3 sets of readfiles are not needed beyond this stage. Only the subsampled reads in Nextflow $WORK are used by the pipeline after this step.

Also did some general Nextflow formatting :)