### PR TITLE
Cleanup reshuffle

### DIFF
--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -125,6 +125,7 @@ process subsampling {
     publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/subsampling", mode: 'copy'
 
     input:
+    val logfile from cleanup_ch1
     tuple sample_id, readPair from cleanedReads
     
     output:
@@ -134,6 +135,9 @@ process subsampling {
 
     shell:
     '''
+    sleep 15
+    ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz > cleanup.txt || echo "no files found"
+    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz || echo "nothing to delete"
     READFILE1=$(echo !{readPair[0]})
     READCOUNT=$(zcat $READFILE1|echo $(wc -l)/4|bc)
     echo $READCOUNT > !{sample_id}_subsampling.log
@@ -152,32 +156,14 @@ process subsampling {
         mv $READFILE1 .
         mv $READFILE2 .
     fi
-    '''
-}
-
-/*
- * PRE-STEP vii - clean up intermediate readfiles to save disk space
-*/
-
-process intermediate_reads_cleanup {
-    input:
-    val logfile from cleanup_ch1
-    val sample_id from cleanup_ch2
-    val logfile2 from cleanup_ch3
-
-    shell:
-    '''
-    sleep 30
     CLEANUPDIR=$(dirname !{logfile})
-    echo !{sample_id} > cleanup.txt
     ls $CLEANUPDIR/*.fastq.gz >> cleanup.txt || echo "no files found"
     rm $CLEANUPDIR/*.fastq.gz || echo "nothing to delete"
-    ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz >> cleanup.txt || echo "no files found"
-    rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/fastp/*.fastq.gz || echo "nothing to delete"
     ls $HOME/WGS_Results/!{params.runID}/!{sample_id}/subsampling/*.fastq.gz >> cleanup.txt || echo "no files found"
     rm $HOME/WGS_Results/!{params.runID}/!{sample_id}/subsampling/*.fastq.gz || echo "nothing to delete"
     '''
 }
+
 
 /*
  * STEP 1 - fastqc

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -483,3 +483,4 @@ process final_cleanup {
     rm $HOME/WGS_Results/${params.runID}/${sample_id}/srst2/${sample_id}_8.txt || echo "nothing to delete"
     """
 }
+

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -22,7 +22,7 @@ println readPath
  * PRE-STEP ii - Initial pre-processing run at the start of the nextflow run
 */
 
-process pre_process {
+process git_sha {
     """
     # Save the git-sha into the results folder
     mkdir -p $publishDirectory
@@ -64,14 +64,12 @@ names1
     .merge(countInt1)
     .merge(files1)
     .filter {it[1] >= params.minReads}
-    .view()
     .set{runCh}
 
 names2
     .merge(countInt2)
     .merge(files2)
     .filter {it[1] < params.minReads}
-    .view()
     .set{skipCh}
 
 
@@ -129,8 +127,8 @@ process subsampling {
     tuple sample_id, readPair from cleanedReads
     
     output:
-    val sample_id into cleanup_ch2
-    file("*_subsampling.log") into cleanup_ch3
+    file("*_subsampling.log")
+    file("cleanup.txt")
     tuple sample_id, file("*_{R1,R2}.fastq.gz") into reads1, reads2, reads3, reads4, reads5, reads6, reads7, reads8, reads9, reads_summ1, reads_summ2
 
     shell:
@@ -430,10 +428,10 @@ process summary {
 
 
 /*
- * STEP 10 - remove text files 
+ * STEP 10 - final cleanup
 */
 
-process remove {
+process final_cleanup {
     input:
     tuple sample_id, file(reads_file) from reads9
     val read_rem from reads_summ2.count()

--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -128,6 +128,7 @@ process subsampling {
     
     output:
     file("*_subsampling.log") into cleanup_ch2
+    val sample_id into cleanup_ch3
     tuple sample_id, file("*_{R1,R2}.fastq.gz") into reads1, reads2, reads3, reads4, reads5, reads6, reads7, reads8, reads9, reads_summ1, reads_summ2
 
     shell:
@@ -167,6 +168,7 @@ process subsampling {
 process intermediate_reads_cleanup {
     input:
     val logfile2 from cleanup_ch2
+    val sample_id from cleanup_ch3
 
     shell:
     '''


### PR DESCRIPTION
Annoyingly, Nextflow seems to want to completely finish fastp trimming and subsampling ALL isolates BEFORE it applies the new Cleanup process. I was hoping that cleanup would happen intermittently as isolates pass through both prior stages, but that doesn't seem to be the case. Nextflow is still filling up disk space before it can actually get around to freeing it up!

Thus, to allow the Validation panel or any other large dataset to run, I have moved some of the Cleanup commands inside the Subsampling process so that this stage does some space saving as it goes. Then the rest of the Cleanup follows Subsampling as before.