### PR TITLE
Update install_pipeline_local_RANCH210.sh

### DIFF
--- a/local_install/install_pipeline_local_RANCH210.sh
+++ b/local_install/install_pipeline_local_RANCH210.sh
@@ -188,6 +188,7 @@ pip install pandas==1.0.5
 # rm -rf srst2
 # rm srst2.zip
 
+pip install samtools==1.12
 
 #################################################################################################
 # Nextflow


### PR DESCRIPTION
version pin samtools to 1.12 so srst2 stops complaining (default conda install of samtools right now is v1.15 and that's too up-to-date for srst2)