### PR TITLE
keep trimmed files

### DIFF
--- a/SCE3_pipeline_update.nf
+++ b/SCE3_pipeline_update.nf
@@ -63,13 +63,29 @@ names1
     .merge(countInt1)
     .merge(files1)
     .filter {it[1] >= params.minReads}
-    .set{runCh}
+    .into{runCh; countCh}
 
 names2
     .merge(countInt2)
     .merge(files2)
     .filter {it[1] < params.minReads}
     .set{skipCh}
+
+process fastq_size_check {
+    input:
+    val runCount from countCh.count()
+
+    output:
+    val go into goCh1, goCh2
+
+    exec:
+    if (runCount > 0) {
+        go = 1
+    }
+    else {
+        error "ERROR: No input .fastq.gz files found or all input .fastq.gz files < 500K reads"
+    }
+}
 
 
 /*
@@ -80,6 +96,7 @@ samplecount_ch = Channel.fromFilePairs(readPath)
 
 process instantiate_summary_table {
     input:
+    val go from goCh1
     val sample_count from samplecount_ch.count()
     val counted_samples from out_iii.count()
 
@@ -101,6 +118,7 @@ process fastp_qual_trim {
     publishDir "$HOME/WGS_Results/${params.runID}/${sample_id}/fastp", mode: 'copy'
 
     input:
+    val go from goCh2
     tuple sample_id, readCount, readFile1, readFile2 from runCh
 
     output:
@@ -156,6 +174,8 @@ process subsampling {
     CLEANUPDIR=$(dirname !{logfile})
     ls $CLEANUPDIR/*.fastq.gz >> cleanup.txt || echo "no files found"
     rm $CLEANUPDIR/*.fastq.gz || echo "nothing to delete"
+    cp $(basename $READFILE1) $HOME/WGS_Data/!{params.runID}
+    cp $(basename $READFILE2) $HOME/WGS_Data/!{params.runID}
     '''
 }
 


### PR DESCRIPTION
Implemented a copy step to replace the (often very large) raw fastq.gz files with the subsampled and trimmed files, which are much better for UKHSA uploads.

Also wrote a new Nextflow process which checks that at least one input file is >500K reads and throws an intentional Error if not. 

