### PR TITLE
fix paths with os.path.expanduser()

### DIFF
--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -47,7 +47,8 @@ def upload_s3(file_path, s3_destination, **kwargs):
     """
         Uploads a file to S3
     """
-    run(["aws", "s3", "cp", file_path, s3_destination], **kwargs)
+    run(["aws", "s3", "cp", file_path, s3_destination, "--acl",
+         "bucket-owner-full-control"], **kwargs)
 
 
 def s3_object_release_date(s3_key):
@@ -163,7 +164,8 @@ if __name__ == '__main__':
     # setup logging
     log_file_path = os.path.expanduser("~/batch_process_plate.log")
     logging.basicConfig(level=logging.INFO, format="%(message)s",
-                        handlers=[logging.FileHandler(log_file_path)])
+                        handlers=[logging.StreamHandler(),
+                                  logging.FileHandler(log_file_path)])
 
     # Run
     try:

--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -4,7 +4,7 @@ import glob
 import argparse
 import logging
 
-DEFAULT_READS_DIRECTORY = os.path.expanduser('~/root/wgs-reads')
+DEFAULT_READS_DIRECTORY = os.path.expanduser('~/wgs-reads')
 DEFAULT_KMER_URI = "s3://s3-ranch-046/KmerID_Ref_Genomes"
 
 
@@ -137,7 +137,7 @@ def run_plate(reads_uri, reads_dir, results_uri, kmer_uri):
     # Upload results to s3
     plate_name = s3_uri_to_plate_name(reads_uri)
     TableFile_name = plate_name + "_SummaryTable_plusLIMS.csv"
-    summaryTable_path = os.path.join("~/root/wgs-results/", plate_name,
+    summaryTable_path = os.path.join("~/wgs-results/", plate_name,
                                      TableFile_name)
     summaryTable_path = os.path.expanduser(summaryTable_path)
     logging.info(f"Uploading results: {results_uri}")
@@ -161,7 +161,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # setup logging
-    log_file_path = os.path.expanduser("~/root/batch_process_plate.log")
+    log_file_path = os.path.expanduser("~/batch_process_plate.log")
     logging.basicConfig(level=logging.INFO, format="%(message)s",
                         handlers=[logging.FileHandler(log_file_path)])
 


### PR DESCRIPTION
This PR is a simple bugfix of something I missed in my previous PR. 

I was a little confused about how `os.expanduser()` was working, hopefully I've got it right now...

Perhaps you could confirm @ahussaini821 ?

So we want `wgs-reads` and `wgs-results` to be in the users home directory, right? I think therefore we want to omit `root` from those paths so that `os.expanduser("~/wgs-reads") would just be `/home/user/wgs-reads`?

Also could you confirm that `run_pipeline(), line 35 is correct @ahussaini821? Not sure if `root/nextflow/nextflow` would be the correct path for nextflow in the docker container? This was just left in from what the code had before...

