### PR TITLE
Print output on timeout

### DIFF
--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -149,7 +149,7 @@ def run_plate(reads_uri, reads_dir, results_uri, kmer_uri):
 
     # Download reference genomes from s3
     logging.info(f"Downloading KmerID reference genomes: {kmer_uri}\n")
-    #download_s3(kmer_uri, "/root/KmerID_Ref_Genomes")
+    download_s3(kmer_uri, "/root/KmerID_Ref_Genomes")
 
     # Download reads
     logging.info(f"Downloading reads: {reads_uri}\n")

--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -32,19 +32,23 @@ def run(cmd, record_output=False):
             (subprocess.run in python docs)
     """
     try:
-        ps = subprocess.run(cmd, capture_output=True)
-        returncode = ps.returncode
+        ps = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+        ps.wait()
         if record_output:
             logging.info(format_subprocess_output(ps.stdout))
-        if returncode:
+        if ps.returncode:
             raise Exception(dedent(f"""
                                     *****
-                                    cmd '{(" ").join(cmd)}' failed with exit code {returncode}
+                                    cmd '{(" ").join(cmd)}' failed with exit code {ps.returncode}
                                     {format_subprocess_output(ps.stderr)}
                                     *****
                                     """))
     except TimeoutError as e:
-        logging.info(format_subprocess_output(ps.stdout))
+        print("hello")
+        ps.kill()
+        print(format_subprocess_output(ps.stdout.read() + b"\n"))
+        #logging.info(format_subprocess_output(ps.stdout))
         raise e
 
 
@@ -201,7 +205,7 @@ if __name__ == '__main__':
         results_uri = args.results_uri
     except Exception as e:
         if isinstance(e, TimeoutError):
-            # append "_timout" to the results_uri
+            # append "_timeout" to the results_uri
             results_uri = f"{args.results_uri.rstrip('/')}_timeout_error"
         else:
             # append "_failed" to the results_uri

--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -31,17 +31,21 @@ def run(cmd, record_output=False):
             cmd (list): List of strings defining the command, see
             (subprocess.run in python docs)
     """
-    ps = subprocess.run(cmd, capture_output=True)
-    returncode = ps.returncode
-    if record_output:
+    try:
+        ps = subprocess.run(cmd, capture_output=True)
+        returncode = ps.returncode
+        if record_output:
+            logging.info(format_subprocess_output(ps.stdout))
+        if returncode:
+            raise Exception(dedent(f"""
+                                    *****
+                                    cmd '{(" ").join(cmd)}' failed with exit code {returncode}
+                                    {format_subprocess_output(ps.stderr)}
+                                    *****
+                                    """))
+    except TimeoutError as e:
         logging.info(format_subprocess_output(ps.stdout))
-    if returncode:
-        raise Exception(dedent(f"""
-                                   *****
-                                   cmd '{(" ").join(cmd)}' failed with exit code {returncode}
-                                   {format_subprocess_output(ps.stderr)}
-                                   *****
-                                """))
+        raise e
 
 
 def format_subprocess_output(output):
@@ -137,7 +141,7 @@ def run_plate(reads_uri, reads_dir, results_uri, kmer_uri):
 
     # Download reference genomes from s3
     logging.info(f"Downloading KmerID reference genomes: {kmer_uri}\n")
-    download_s3(kmer_uri, "/root/KmerID_Ref_Genomes")
+    #download_s3(kmer_uri, "/root/KmerID_Ref_Genomes")
 
     # Download reads
     logging.info(f"Downloading reads: {reads_uri}\n")


### PR DESCRIPTION
Adds a feature which prints stdout of subprocess to the logfile even if the program experiences a "SIGTERM" (timeout) or the subprocess fails.

This was an essential feature for determining reason for failure in AWS batch (especially with timeouts).

When using `subprocess.run()` the stdout of the subprocess was only available if `subprocess.run()` actually successfully returns. If a timeout occurs the subprocess call will terminate early meaning stdout is unavailable.

Instead using `subproccess.Popen()`, the output can be written to a temporary file throughout execution. We use a try/except block to catch `TimoutErrors` across the `Popen()` call. In the Except block the contents of the temporary file are logged. 