### PR TITLE
Master summary update batch

### DIFF
--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 
 DEFAULT_READS_DIRECTORY = os.path.expanduser('~/wgs-reads')
 DEFAULT_KMER_URI = "s3://s3-ranch-046/KmerID_Ref_Genomes"
-DEFAULT_MASTER_SUMMARY_URI = "s3://s3-ranch-050/master_sum.csv"
+DEFAULT_MASTER_SUMMARY_URI = "s3://s3-ranch-050/master_summary.csv"
 
 
 class TimeoutHandler:

--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -152,7 +152,7 @@ def update_master_summary(TableFile_name,
     """
     df_new_sum = pd.read_csv(TableFile_name)
     download_s3(master_sum_uri, "master_sum.csv", record_output=True)
-    df_new_sum.to_csv("master_sum.csv", mode="a", index=False)
+    df_new_sum.to_csv("master_sum.csv", mode="a", header=False, index=False)
     upload_s3("master_sum.csv", master_sum_uri, record_output=True)
 
 

--- a/plate/batch_process_plate.py
+++ b/plate/batch_process_plate.py
@@ -150,8 +150,8 @@ def update_master_summary(TableFile_name,
         appending the latest results to a master CSV containing all
         historical results
     """
-    download_s3(master_sum_uri, "master_sum.csv", record_output=True)
     df_new_sum = pd.read_csv(TableFile_name)
+    download_s3(master_sum_uri, "master_sum.csv", record_output=True)
     df_new_sum.to_csv("master_sum.csv", mode="a", index=False)
     upload_s3("master_sum.csv", master_sum_uri, record_output=True)
 


### PR DESCRIPTION
As discussed, this PR introduces functionality to update a master summary table which will sit in `s3-ranch-050`. It will be at `s3://s3-ranch-050/master_summary.csv`.

There is an additional function, `update_master_summary()`, which parses the current summary table (for the current batch run), downloads the master summary from s3, appends the parsed summary to the master summary CSV and uploads to the same s3 uri, thus replacing the old master summary table.

This routine is performed after uploading the pipeline results to s3 (line 195).

I have added functionality to `download_s3()` so that this can operate on file (i.e. without recursive).